### PR TITLE
Fix #2343, shorten deleted username display

### DIFF
--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -331,7 +331,7 @@ export function Player(props: PlayerProperties): JSX.Element {
     let display_username = username_string;
 
     if (username_string.toLowerCase().startsWith("deleted-")) {
-        display_username = display_username.substring(0, 15)+"...";
+        display_username = display_username.substring(0, 15) + "...";
     }
 
     const username = <span className="Player-username">{display_username}</span>;

--- a/src/components/Player/Player.tsx
+++ b/src/components/Player/Player.tsx
@@ -328,7 +328,13 @@ export function Player(props: PlayerProperties): JSX.Element {
     }
 
     const username_string = unicodeFilter(combined.username || combined.name || "<error>");
-    const username = <span className="Player-username">{username_string}</span>;
+    let display_username = username_string;
+
+    if (username_string.toLowerCase().startsWith("deleted-")) {
+        display_username = display_username.substring(0, 15)+"...";
+    }
+
+    const username = <span className="Player-username">{display_username}</span>;
 
     const player_note_indicator =
         props.shownotesindicator && has_notes ? (


### PR DESCRIPTION
Fixes #2343

## Proposed Changes

This shortens a deleted username's display to be `deleted-xyz...`

## Before:
<img width="1141" alt="image" src="https://github.com/cassidoo/online-go.com/assets/1454517/3fb2e084-6623-43ef-ad58-a22b6ae4c191">

## After:
<img width="863" alt="image" src="https://github.com/cassidoo/online-go.com/assets/1454517/fdeba713-818b-4417-8fa9-d0ead5589faa">
