### PR TITLE
Adjust Player username margin in ProfileCard styles

### DIFF
--- a/src/components/ProfileCard/ProfileCard.styl
+++ b/src/components/ProfileCard/ProfileCard.styl
@@ -28,6 +28,10 @@
         flex-direction: column;
         padding-left: 1rem;
         justify-content: space-between;
+
+        .Player .Player-username {
+            margin: 0;
+        }
     }
 
     .PlayerIcon {


### PR DESCRIPTION
Currently on OGS, there is a slight leading margin on the player's username in `.Player .Player-username` (.25rem to be exact). On the homepage, it shows slightly off compared to other elements:

<img width="351" height="246" alt="image" src="https://github.com/user-attachments/assets/91a2ddf3-af02-479b-9191-0047395f5425" />

It *may* be worth removing the margin entirely from `src/components/Player/Player.styl`. I went through a few parts of the site to check out if it was necessary and couldn't find any use cases, but it's possible I missed some.
